### PR TITLE
Remove println in response decoding

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -20,8 +20,6 @@ func newJSONResponseDecoder() responseDecoder {
 func (j jsonResponseDecoder) decode(subject Response, response io.ReadCloser, status int) (Response, error) {
 	responseAsString := tryReadCloserToString(response)
 
-	fmt.Println("Response " + responseAsString)
-
 	// Decode the response into the expected response type
 	decoded, err := subject.Decode(ioutil.NopCloser(strings.NewReader(responseAsString)))
 	if err != nil {


### PR DESCRIPTION
Each call to the library results in the entire json response object being outputted to stdout. In order to get around this I have to temporarily reassign os.Stdout to nil, call the command, then reassign os.Stdout. 

If this response log output is required, perhaps it would be better to use a logger with 'debug' or accept a verbose parameter?

(btw nice library, thanks :)